### PR TITLE
Converting non-string types to their approriate type when getting task data from Redis

### DIFF
--- a/blueque/redis_task.py
+++ b/blueque/redis_task.py
@@ -1,4 +1,13 @@
+from collections import defaultdict
+
+
 class RedisTask(object):
+    _field_types = defaultdict(lambda: str, {
+        "pid": int,
+        "created": float,
+        "updated": float
+    })
+
     def __init__(self, id, redis):
         super(RedisTask, self).__init__()
 
@@ -15,4 +24,9 @@ class RedisTask(object):
         return '_'.join(("blueque",) + args)
 
     def get_task_data(self):
-        return self._redis.hgetall(self._task_key)
+        task_data = {}
+
+        for field, value in self._redis.hgetall(self._task_key).iteritems():
+            task_data[field] = self._field_types[field](value)
+
+        return task_data

--- a/tests/test_forking_runner.py
+++ b/tests/test_forking_runner.py
@@ -72,7 +72,7 @@ class TestForkingRunner(unittest.TestCase):
             mock_listener = mock_get_listener.return_value
             mock_listener.listen.side_effect = BreakLoop()
             mock_listener.claim_orphan.side_effect = [
-                self._get_task(status="started", pid=1111), None]
+                self._get_task(status="started", pid="1111"), None]
 
             try:
                 self.runner.run()
@@ -97,8 +97,8 @@ class TestForkingRunner(unittest.TestCase):
             mock_listener = mock_get_listener.return_value
             mock_listener.listen.side_effect = BreakLoop()
             mock_listener.claim_orphan.side_effect = [
-                self._get_task(status="started", pid=1111),
-                self._get_task(status="started", pid=2222),
+                self._get_task(status="started", pid="1111"),
+                self._get_task(status="started", pid="2222"),
                 None]
 
             try:

--- a/tests/test_redis_task.py
+++ b/tests/test_redis_task.py
@@ -19,3 +19,22 @@ class TestRedisTask(unittest.TestCase):
         self.mock_redis.hgetall.assert_called_with("blueque_task_some_task")
 
         self.assertEqual({"status": "pending"}, task_data)
+
+    def test_get_task_data_converts_types(self):
+        self.mock_redis.hgetall.return_value = {
+            "status": "pending",
+            "pid": "1234",
+            "created": "23.45",
+            "updated": "34.56"
+        }
+
+        task_data = self.redis_task.get_task_data()
+
+        self.mock_redis.hgetall.assert_called_with("blueque_task_some_task")
+
+        self.assertEqual({
+            "status": "pending",
+            "pid": 1234,
+            "created": 23.45,
+            "updated": 34.56
+        }, task_data)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -11,9 +11,9 @@ FULL_TASK_DATA = {
     "result": "a result",
     "error": "no error",
     "node": "some_node",
-    "pid": 1234,
-    "created": 1234.5,
-    "updated": 4567.89
+    "pid": "1234",
+    "created": "1234.5",
+    "updated": "4567.89"
 }
 
 


### PR DESCRIPTION
@ckrough @fearphage @hiwaylon @joshmarshall Can one of you look at this?

It fixes: https://www.pivotaltracker.com/story/show/60987712

The problem was we were passing a string value to os.kill, when it wants an int.
