### PR TITLE
Adding a manifest, so pip install can use requirements.txt to install the requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as requirements_file:
                           map(lambda r: r.strip(), requirements_file.readlines()))
 
 setup(name="blueque",
-      version="0.2",
+      version="0.2.1",
       description="Simple job queuing for very long tasks",
       url="https://github.com/ustudio/Blueque",
       packages=["blueque"],


### PR DESCRIPTION
We should really be specifying only the runtime requirements in the setup.py (which should just be `redis`), but this change is smaller, since we have a broken build up on PyPI.

@ustudio/dev For your consideration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/blueque/6)
<!-- Reviewable:end -->
