### PR TITLE
Passes all keyword arguments to redis-py constructor

### DIFF
--- a/blueque/client.py
+++ b/blueque/client.py
@@ -9,10 +9,10 @@ import redis
 
 
 class Client(object):
-    def __init__(self, hostname, port, db):
+    def __init__(self, hostname, port, db, **kwargs):
         super(Client, self).__init__()
 
-        self._redis = redis.StrictRedis(host=hostname, port=port, db=db)
+        self._redis = redis.StrictRedis(host=hostname, port=port, db=db, **kwargs)
 
     def get_queue(self, name):
         redis_queue = RedisQueue(name, self._redis)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as requirements_file:
                           map(lambda r: r.strip(), requirements_file.readlines()))
 
 setup(name="blueque",
-      version="0.2.1",
+      version="0.2.2",
       description="Simple job queuing for very long tasks",
       url="https://github.com/ustudio/Blueque",
       packages=["blueque"],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,9 +9,14 @@ class TestClient(unittest.TestCase):
     # classes they create.
 
     @mock.patch("redis.StrictRedis", autospec=True)
-    def setUp(self, mock_redis):
+    def test_client_connects_with_requested_information(self, mock_redis):
         self.client = Client(hostname="foo", port=1234, db=0)
-        self.mock_redis = mock_redis
 
-    def test_client_connects_with_requested_information(self):
-        self.mock_redis.assert_called_with(host="foo", port=1234, db=0)
+        mock_redis.assert_called_with(host="foo", port=1234, db=0)
+
+    @mock.patch("redis.StrictRedis", autospec=True)
+    def test_client_passes_additional_args_to_client(self, mock_redis):
+        self.client = Client(hostname="foo", port=1234, db=0, password="password", charset="utf8")
+
+        mock_redis.assert_called_with(
+            host="foo", port=1234, db=0, password="password", charset="utf8")


### PR DESCRIPTION
Does what it says on the tin.

@ustudio/dev :eyes:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/blueque/7)
<!-- Reviewable:end -->
