### PR TITLE
call logging.debug for unimportant log messages so we don't flood the logs unnecessarily

### DIFF
--- a/blueque/redis_queue.py
+++ b/blueque/redis_queue.py
@@ -37,6 +37,9 @@ class RedisQueue(object):
     def _log(self, message):
         logging.info("Blueque queue %s: %s" % (self._name, message))
 
+    def _debug(self, message):
+        logging.debug("Blueque queue %s: %s" % (self._name, message))
+
     def add_listener(self, node_id):
         self._log("adding listener %s" % (node_id))
         with self._redis.pipeline() as pipeline:
@@ -110,7 +113,7 @@ class RedisQueue(object):
             due_tasks = pipeline.zrangebyscore(self._scheduled_key, 0, now)
 
             if len(due_tasks) == 0:
-                self._log("no due tasks")
+                self._debug("no due tasks")
                 return
 
             self._log("enqueuing due tasks: %s" % (due_tasks))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="blueque",
-      version="0.2.2",
+      version="0.2.3",
       description="Simple job queuing for very long tasks",
       url="https://github.com/ustudio/Blueque",
       packages=["blueque"],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="blueque",
-      version="0.2.3",
+      version="0.2.4",
       description="Simple job queuing for very long tasks",
       url="https://github.com/ustudio/Blueque",
       packages=["blueque"],

--- a/tests/test_redis_queue.py
+++ b/tests/test_redis_queue.py
@@ -24,12 +24,16 @@ class TestRedisQueue(unittest.TestCase):
         self.log_info_patch = mock.patch("logging.info", autospec=True)
         self.log_info = self.log_info_patch.start()
 
+        self.log_debug_patch = mock.patch("logging.debug", autospec=True)
+        self.log_debug = self.log_debug_patch.start()
+
         self.queue = RedisQueue("some.queue", self.mock_redis)
 
     def tearDown(self):
         self.uuid_patch.stop()
         self.time_patch.stop()
         self.log_info_patch.stop()
+        self.log_debug_patch.stop()
 
     def _get_pipeline(self):
         return self.mock_redis.pipeline.return_value.__enter__.return_value
@@ -359,4 +363,4 @@ class TestRedisQueue(unittest.TestCase):
 
         self.assertFalse(pipeline.zremrangebyscore.called)
 
-        self.log_info.assert_called_with("Blueque queue some.queue: no due tasks")
+        self.log_debug.assert_called_with("Blueque queue some.queue: no due tasks")

--- a/tests/test_redis_queue.py
+++ b/tests/test_redis_queue.py
@@ -29,11 +29,10 @@ class TestRedisQueue(unittest.TestCase):
 
         self.queue = RedisQueue("some.queue", self.mock_redis)
 
-    def tearDown(self):
-        self.uuid_patch.stop()
-        self.time_patch.stop()
-        self.log_info_patch.stop()
-        self.log_debug_patch.stop()
+        self.addCleanup(self.uuid_patch.stop)
+        self.addCleanup(self.time_patch.stop)
+        self.addCleanup(self.log_info_patch.stop)
+        self.addCleanup(self.log_debug_patch.stop)
 
     def _get_pipeline(self):
         return self.mock_redis.pipeline.return_value.__enter__.return_value

--- a/tests/test_redis_queue.py
+++ b/tests/test_redis_queue.py
@@ -17,22 +17,21 @@ class TestRedisQueue(unittest.TestCase):
         self.uuid_patch = mock.patch(
             "uuid.uuid4", return_value=uuid.UUID("{12345678-1234-1234-1234-123456781234}"))
         self.uuid_patch.start()
+        self.addCleanup(self.uuid_patch.stop)
 
         self.time_patch = mock.patch("time.time", return_value=12.34)
         self.mock_time = self.time_patch.start()
+        self.addCleanup(self.time_patch.stop)
 
         self.log_info_patch = mock.patch("logging.info", autospec=True)
         self.log_info = self.log_info_patch.start()
+        self.addCleanup(self.log_info_patch.stop)
 
         self.log_debug_patch = mock.patch("logging.debug", autospec=True)
         self.log_debug = self.log_debug_patch.start()
+        self.addCleanup(self.log_debug_patch.stop)
 
         self.queue = RedisQueue("some.queue", self.mock_redis)
-
-        self.addCleanup(self.uuid_patch.stop)
-        self.addCleanup(self.time_patch.stop)
-        self.addCleanup(self.log_info_patch.stop)
-        self.addCleanup(self.log_debug_patch.stop)
 
     def _get_pipeline(self):
         return self.mock_redis.pipeline.return_value.__enter__.return_value

--- a/tests/test_redis_queue.py
+++ b/tests/test_redis_queue.py
@@ -123,7 +123,8 @@ class TestRedisQueue(unittest.TestCase):
         pipeline.execute.assert_called_with()
 
         self.log_info.assert_called_with(
-            "Blueque queue some.queue: adding pending task 12345678-1234-1234-1234-123456781234, parameters: some parameter")
+            "Blueque queue some.queue: adding pending task "
+            "12345678-1234-1234-1234-123456781234, parameters: some parameter")
 
     def test_dequeue(self):
         self.mock_redis.rpoplpush.return_value = "1234"
@@ -173,7 +174,8 @@ class TestRedisQueue(unittest.TestCase):
         pipeline.execute.assert_called_with()
 
         self.log_info.assert_has_calls([
-            mock.call("Blueque queue some.queue: starting task some_task on some_node, pid 4321")
+            mock.call(
+                "Blueque queue some.queue: starting task some_task on some_node, pid 4321")
         ])
 
     def test_complete_task(self):
@@ -181,7 +183,8 @@ class TestRedisQueue(unittest.TestCase):
 
         self.queue.complete("some_task", "some_node", 1234, "a result")
 
-        pipeline.lrem.assert_called_with("blueque_reserved_tasks_some.queue_some_node", 1, "some_task")
+        pipeline.lrem.assert_called_with(
+            "blueque_reserved_tasks_some.queue_some_node", 1, "some_task")
         pipeline.srem.assert_called_with(
             "blueque_started_tasks_some.queue", "some_node 1234 some_task")
 
@@ -198,14 +201,16 @@ class TestRedisQueue(unittest.TestCase):
         pipeline.execute.assert_called_with()
 
         self.log_info.assert_called_with(
-            "Blueque queue some.queue: completing task some_task on some_node, pid: 1234, result: a result")
+            "Blueque queue some.queue: completing task some_task on some_node, "
+            "pid: 1234, result: a result")
 
     def test_fail_task(self):
         pipeline = self._get_pipeline()
 
         self.queue.fail("some_task", "some_node", 1234, "error message")
 
-        pipeline.lrem.assert_called_with("blueque_reserved_tasks_some.queue_some_node", 1, "some_task")
+        pipeline.lrem.assert_called_with(
+            "blueque_reserved_tasks_some.queue_some_node", 1, "some_task")
         pipeline.srem.assert_called_with(
             "blueque_started_tasks_some.queue", "some_node 1234 some_task")
 
@@ -222,7 +227,8 @@ class TestRedisQueue(unittest.TestCase):
         pipeline.execute.assert_called_with()
 
         self.log_info.assert_called_with(
-            "Blueque queue some.queue: failed task some_task on some_node, pid: 1234, error: error message")
+            "Blueque queue some.queue: failed task some_task on some_node, "
+            "pid: 1234, error: error message")
 
     def test_delete_completed_task(self):
         pipeline = self._get_pipeline()
@@ -281,7 +287,8 @@ class TestRedisQueue(unittest.TestCase):
         pipeline.execute.assert_called_with()
 
         self.log_info.assert_called_with(
-            "Blueque queue some.queue: adding scheduled task 12345678-1234-1234-1234-123456781234, parameters: some parameters")
+            "Blueque queue some.queue: adding scheduled task "
+            "12345678-1234-1234-1234-123456781234, parameters: some parameters")
 
     def test_schedule_with_past_eta_just_enqueues(self):
         self.queue.enqueue = mock.Mock()


### PR DESCRIPTION
@ustudio/dev please review

- Blueque was logging when "no due tasks" were found and this was causing a flood of log messages.  This changes that one statement to be logged at DEBUG level so we don't fill the logs unnecessarily.
- bumped version to 0.2.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/blueque/9)
<!-- Reviewable:end -->
