### PR TITLE
Reduce log spam

### DIFF
--- a/blueque/redis_queue.py
+++ b/blueque/redis_queue.py
@@ -129,7 +129,7 @@ class RedisQueue(object):
         self._redis.transaction(enqueue_transaction, self._scheduled_key)
 
     def dequeue(self, node_id):
-        self._log("reserving task on %s" % (node_id))
+        self._debug("reserving task on %s" % (node_id))
 
         task_id = self._redis.rpoplpush(
             self._pending_name, self._reserved_key(node_id))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="blueque",
-      version="0.2.4",
+      version="0.2.5",
       description="Simple job queuing for very long tasks",
       url="https://github.com/ustudio/Blueque",
       packages=["blueque"],

--- a/tests/test_redis_queue.py
+++ b/tests/test_redis_queue.py
@@ -140,8 +140,11 @@ class TestRedisQueue(unittest.TestCase):
         self.mock_redis.hmset.assert_called_with(
             "blueque_task_1234", {"status": "reserved", "node": "some_node", "updated": 12.34})
 
+        self.log_debug.assert_has_calls([
+            mock.call("Blueque queue some.queue: reserving task on some_node")
+        ])
+
         self.log_info.assert_has_calls([
-            mock.call("Blueque queue some.queue: reserving task on some_node"),
             mock.call("Blueque queue some.queue: got task 1234")
         ])
 
@@ -156,7 +159,7 @@ class TestRedisQueue(unittest.TestCase):
             "blueque_pending_tasks_some.queue", "blueque_reserved_tasks_some.queue_some_node")
         self.mock_redis.hmset.assert_has_calls([])
 
-        self.log_info.assert_has_calls([
+        self.log_debug.assert_has_calls([
             mock.call("Blueque queue some.queue: reserving task on some_node")
         ])
 


### PR DESCRIPTION
This downgrades another log message from info to debug, because it was being logged on every polling iteration, even if there were no tasks in the queue, resulting in tons of log messages.

@ustudio/dev Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/blueque/10)
<!-- Reviewable:end -->
