### PR TITLE
Update circle to build tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,14 @@ workflows:
   version: 2
   test-and-publish:
     jobs:
-      - test-python27
-      - test-python37
+      - test-python27:
+          filters:
+            tags:
+              only: /.*/
+      - test-python37:
+          filters:
+            tags:
+              only: /.*/
       - publish:
           requires:
             - test-python27

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="blueque",
-      version="0.3.0",
+      version="0.3.1",
       description="Simple job queuing for very long tasks",
       url="https://github.com/ustudio/Blueque",
       packages=["blueque"],


### PR DESCRIPTION
CircleCI wasn't building the release tag because it ignores tags, by default. This should make CircleCI build release tags.

@ustudio/reviewers Please review