### PR TITLE
Use CircleCI Contexts for Credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,4 +144,4 @@ workflows:
               only: /^v[0-9]+(\.[0-9]+)*.*/
             branches:
               ignore: /.*/
-          context: org-global
+          context: blueque-publisher

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,66 +1,22 @@
 version: 2
 jobs:
-  test-python27:
-    docker:
-      - image: circleci/python:2.7
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v2-dependencies-python27-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
-            - v2-dependencies-python27-{{ checksum "setup.py" }}-
-            - v2-dependencies-python27-
-
-      - run:
-          name: Install Dependencies
-          command: |
-            python -m virtualenv ~/venv
-            . ~/venv/bin/activate
-            pip install -e .
-            pip install -r requirements.txt
-            mkdir -p test-reports
-
-      - save_cache:
-          paths:
-            - ~/venv
-          key: v2-dependencies-python27-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
-
-      - run:
-          name: Run Tests
-          command: |
-            . ~/venv/bin/activate
-            nosetests --verbose --with-xunit --xunit-file=test-reports/nosetests-python27.xml
-
-      - run:
-          name: Run Linter
-          command: |
-            . ~/venv/bin/activate
-            flake8
-
-      - store_artifacts:
-          path: test-reports
-
-      - store_test_results:
-          path: test-reports
-
   test-python37:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
 
     working_directory: ~/repo
 
     steps:
       - checkout
 
+      - run:
+          name: Save Python Version
+          command: |
+            python --version > pythonversion
+
       - restore_cache:
           keys:
-            - v2-dependencies-python37-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
-            - v2-dependencies-python37-{{ checksum "setup.py" }}-
-            - v2-dependencies-python37-
+            - v2-python-{{ checksum "pythonversion" }}-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
 
       - run:
           name: Install Dependencies
@@ -74,7 +30,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: v2-dependencies-python37-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
+          key: v2-python-{{ checksum "pythonversion" }}-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
 
       - run:
           name: Run Tests
@@ -96,14 +52,10 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     working_directory: ~/repo
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-          - v2-publish-dependencies-
 
       - run:
           name: Install Dependencies
@@ -111,11 +63,6 @@ jobs:
             python -m virtualenv ~/venv
             . ~/venv/bin/activate
             pip install twine
-
-      - save_cache:
-          paths:
-            - ~/venv
-          key: v2-publish-dependencies-
 
       - run:
           name: Publish to PyPI
@@ -127,17 +74,12 @@ workflows:
   version: 2
   test-and-publish:
     jobs:
-      - test-python27:
-          filters:
-            tags:
-              only: /.*/
       - test-python37:
           filters:
             tags:
               only: /.*/
       - publish:
           requires:
-            - test-python27
             - test-python37
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Run Tests
           command: |
             . ~/venv/bin/activate
-            nosetests --verbose --with-xunit --xunit-file=test-reports/nosetests-python37.xml
+            pytest --verbose --junit-xml=test-reports/pytest-python37.xml
 
       - run:
           name: Run Linter

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pluggy==1.0.0
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pytest==7.2.1
+redis==2.10.6
 tomli==2.0.1
 typing_extensions==4.4.0
 zipp==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,15 @@
+attrs==22.2.0
 entrypoints==0.3
+exceptiongroup==1.1.0
 flake8==3.7.8
+importlib-metadata==6.0.0
+iniconfig==2.0.0
 mccabe==0.6.1
+packaging==23.0
+pluggy==1.0.0
 pycodestyle==2.5.0
 pyflakes==2.1.1
+pytest==7.2.1
+tomli==2.0.1
+typing_extensions==4.4.0
+zipp==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+entrypoints==0.3
 flake8==3.7.8
-mock==1.0.1
-nose==1.3.0
+mccabe==0.6.1
+pycodestyle==2.5.0
+pyflakes==2.1.1


### PR DESCRIPTION
This PR updates the CircleCI configuration to use Contexts to manage PyPI credentials, instead of project local variables, which makes managing the credentials easier.

We also removed the test runs for Python 2.7, as it is no longer supported, upgraded to the newer `cimg` CircleCI images, and switched from `nosetests` to `pytest` for test running, since nose has been abandoned for a long time, and no longer worked correctly.

Note: since this is only an update to the test environment, we will not create a new release.

@ustudio/reviewers Please review